### PR TITLE
Add minimal backend and frontend prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,45 @@
+const http = require('http');
+
+const modules = [
+  { id: '1', title: 'Intro to GBS', description: 'Welcome module' },
+  { id: '2', title: 'Advanced Processes', description: 'Deep dive' }
+];
+
+function auth(req, res) {
+  const authHeader = req.headers['authorization'];
+  if (authHeader === 'Bearer dev-token') {
+    return true;
+  }
+  res.writeHead(401, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Unauthorized' }));
+  return false;
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/content/modules') {
+    if (!auth(req, res)) return;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(modules));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/auth/profile') {
+    if (!auth(req, res)) return;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id: 'user1', email: 'user@example.com' }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+const PORT = process.env.PORT || 3001;
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = server;

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const server = require('../server');
+
+const PORT = 4000;
+
+function makeRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'localhost',
+      port: PORT,
+      path,
+      method: 'GET',
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    };
+    const req = http.request(options, res => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test.before(async () => {
+  await new Promise(resolve => server.listen(PORT, resolve));
+});
+
+test.after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+test('requires auth', async () => {
+  const res = await makeRequest('/content/modules');
+  assert.strictEqual(res.status, 401);
+});
+
+test('returns modules when authorized', async () => {
+  const res = await makeRequest('/content/modules', 'dev-token');
+  assert.strictEqual(res.status, 200);
+  const data = JSON.parse(res.body);
+  assert.ok(Array.isArray(data));
+  assert.strictEqual(data.length, 2);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Learning Hub</title>
+</head>
+<body>
+  <h1>Content Modules</h1>
+  <button id="load">Load Modules</button>
+  <ul id="modules"></ul>
+  <script>
+    document.getElementById('load').addEventListener('click', async () => {
+      const res = await fetch('http://localhost:3001/content/modules', {
+        headers: { 'Authorization': 'Bearer dev-token' }
+      });
+      const data = await res.json();
+      const list = document.getElementById('modules');
+      list.innerHTML = '';
+      data.forEach(m => {
+        const li = document.createElement('li');
+        li.textContent = `${m.title} - ${m.description}`;
+        list.appendChild(li);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold backend HTTP server with auth and content modules endpoints
- include simple frontend to fetch and render modules
- add basic tests for authentication and module retrieval

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd54d0388330a6a5991befa374ff