### PR TITLE
feat: add Google auth and RBAC middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "google-auth-library": "^9.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/backend/src/auth/google.ts
+++ b/backend/src/auth/google.ts
@@ -1,0 +1,11 @@
+import { OAuth2Client, TokenPayload } from 'google-auth-library';
+
+const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+
+export async function verifyIdToken(idToken: string): Promise<TokenPayload | undefined> {
+  const ticket = await client.verifyIdToken({
+    idToken,
+    audience: process.env.GOOGLE_CLIENT_ID,
+  });
+  return ticket.getPayload();
+}

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import { verifyIdToken } from '../auth/google';
+import { User } from '../types/user';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: User;
+    }
+  }
+}
+
+export async function authenticate(req: Request, res: Response, next: NextFunction) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Missing Authorization header' });
+  }
+
+  const token = authHeader.substring('Bearer '.length);
+
+  try {
+    const payload = await verifyIdToken(token);
+    if (!payload) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+
+    req.user = {
+      id: payload.sub || '',
+      email: payload.email || '',
+      name: payload.name || '',
+      picture: payload.picture,
+      role: (payload['role'] as User['role']) || 'user',
+    };
+
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}

--- a/backend/src/middleware/authorize.ts
+++ b/backend/src/middleware/authorize.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { Role } from '../types/user';
+
+export function authorize(...roles: Role[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const userRole = req.user?.role;
+    if (!userRole || !roles.includes(userRole)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -1,0 +1,9 @@
+export type Role = 'user' | 'admin';
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  picture?: string;
+  role: Role;
+}


### PR DESCRIPTION
## Summary
- verify Google ID tokens using `google-auth-library`
- introduce `User` interface and basic `admin`/`user` roles
- add authentication middleware to attach Google user data to requests
- add role-based authorization middleware

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fexpress)*
- `npm test` *(fails: Cannot find module 'google-auth-library' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e6bec0d08330a1dc0669142d621e