### PR TITLE
feat: integrate firestore for content modules

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test test/server.test.js"
+    "test": "npm run build && node --test test/server.test.js",
+    "seed:modules": "ts-node scripts/seedModules.ts"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +15,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.19.2",
+    "firebase-admin": "^12.1.1",
     "google-auth-library": "^9.0.0"
   },
   "devDependencies": {

--- a/backend/scripts/seedModules.ts
+++ b/backend/scripts/seedModules.ts
@@ -1,0 +1,21 @@
+import db from '../src/db/firestore';
+
+const modules = [
+  { title: 'Intro to GBS', description: 'Welcome module' },
+  { title: 'Advanced Processes', description: 'Deep dive' },
+];
+
+async function seed() {
+  const batch = db.batch();
+  modules.forEach(mod => {
+    const ref = db.collection('modules').doc();
+    batch.set(ref, mod);
+  });
+  await batch.commit();
+  console.log('Seeded modules');
+}
+
+seed().then(() => process.exit(0)).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/db/firestore.ts
+++ b/backend/src/db/firestore.ts
@@ -1,0 +1,18 @@
+import admin from 'firebase-admin';
+
+const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT
+  ? JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT)
+  : undefined;
+
+if (!admin.apps.length) {
+  if (serviceAccount) {
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount as admin.ServiceAccount),
+    });
+  } else {
+    admin.initializeApp();
+  }
+}
+
+const db = admin.firestore();
+export default db;

--- a/backend/src/routes/content.ts
+++ b/backend/src/routes/content.ts
@@ -1,18 +1,20 @@
 import { Router, Request, Response } from 'express';
+import db from '../db/firestore';
 
 const router = Router();
 
-const modules = [
-  { id: '1', title: 'Intro to GBS', description: 'Welcome module' },
-  { id: '2', title: 'Advanced Processes', description: 'Deep dive' }
-];
-
-router.get('/modules', (req: Request, res: Response) => {
+router.get('/modules', async (req: Request, res: Response) => {
   const authHeader = req.headers['authorization'];
   if (authHeader !== 'Bearer dev-token') {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  res.json(modules);
+  try {
+    const snapshot = await db.collection('modules').get();
+    const modules = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(modules);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch modules' });
+  }
 });
 
 export default router;

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,6 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const http = require('http');
+const db = require('../dist/db/firestore.js').default;
+
+// Mock Firestore collection fetching
+db.collection = () => ({
+  get: async () => ({
+    docs: [
+      { id: '1', data: () => ({ title: 'Intro to GBS', description: 'Welcome module' }) },
+      { id: '2', data: () => ({ title: 'Advanced Processes', description: 'Deep dive' }) },
+    ],
+  }),
+});
+
 const app = require('../dist/index.js').default;
 
 const PORT = 4000;


### PR DESCRIPTION
## Summary
- add Firestore client initialization using service account env
- fetch module content from Firestore instead of hardcoded data
- provide script to seed development modules and mock Firestore in tests

## Testing
- `npm test` *(fails: Cannot find module 'google-auth-library', 'firebase-admin', etc. during tsc compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e85558a08330bcfce4bf021cacac