### PR TITLE
feat: add Cloud Build pipeline

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,12 @@
+# Deployment
+
+This project uses Google Cloud Build to build and deploy the backend to Cloud Run.
+
+## Environment Variables
+
+- `PROJECT_ID`: Google Cloud project identifier where resources are deployed.
+- `SERVICE_NAME`: Cloud Run service name. For this project the service name is `learning-hub`.
+
+## Cloud Build Trigger
+
+Enable a Cloud Build trigger in the Google Cloud console so that pushes to the `main` branch execute the pipeline. See the [Cloud Build trigger documentation](https://cloud.google.com/build/docs/automate-builds/github/create-github-app-triggers) for details.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+COPY src ./src
+RUN npm install
+RUN npm run build
+
+# Production stage
+FROM node:18-slim
+WORKDIR /app
+COPY package.json .
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: 'gcr.io/cloud-builders/npm'
+    dir: 'backend'
+    args: ['install']
+  - name: 'gcr.io/cloud-builders/npm'
+    dir: 'backend'
+    args: ['test']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/learning-hub', 'backend']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args: ['run', 'deploy', 'learning-hub', '--image', 'gcr.io/$PROJECT_ID/learning-hub', '--region', 'us-central1', '--platform', 'managed', '--quiet']
+images:
+  - 'gcr.io/$PROJECT_ID/learning-hub'


### PR DESCRIPTION
## Summary
- add multi-stage backend Dockerfile
- configure Cloud Build to test and deploy the backend to Cloud Run
- document deployment variables and trigger setup

## Testing
- `npm test` *(fails: tsc not found / unable to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea5d6e2c8330a45b7ec4ec46d83c