### PR TITLE
feat: add token auth and docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,8 +4,19 @@ This project uses Google Cloud Build to build and deploy the backend to Cloud Ru
 
 ## Environment Variables
 
+Set the following variables in your Cloud Build trigger or substitutions:
+
 - `PROJECT_ID`: Google Cloud project identifier where resources are deployed.
 - `SERVICE_NAME`: Cloud Run service name. For this project the service name is `learning-hub`.
+
+## Manual Deployment
+
+To build and deploy the backend manually run:
+
+```bash
+gcloud builds submit --config cloudbuild.yaml \
+  --substitutions _SERVICE_NAME=$SERVICE_NAME,PROJECT_ID=$PROJECT_ID
+```
 
 ## Cloud Build Trigger
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# GBS Learning Hub
+
+This repository contains a TypeScript Express backend and a Next.js frontend.
+
+## Backend
+
+Located in `backend/` and built with TypeScript. It exposes authentication and content APIs backed by Firestore.
+
+### Setup
+
+1. Install dependencies:
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Set environment variables:
+   - `GOOGLE_CLIENT_ID` – OAuth client used to verify Google ID tokens.
+   - `FIREBASE_SERVICE_ACCOUNT` – JSON service account credentials for Firestore.
+3. Run the development server:
+   ```bash
+   npm run build
+   npm start
+   ```
+
+## Frontend
+
+The Next.js app lives in `frontend/` and uses React Query to call the backend.
+
+### Setup
+
+1. Install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Create `.env.local` with the backend URL:
+   ```bash
+   NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+   ```
+3. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+
+Visit `http://localhost:3000/modules` to see module data.
+
+## Deployment
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for Cloud Build and Cloud Run deployment instructions.

--- a/backend/src/auth/google.ts
+++ b/backend/src/auth/google.ts
@@ -3,6 +3,15 @@ import { OAuth2Client, TokenPayload } from 'google-auth-library';
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 export async function verifyIdToken(idToken: string): Promise<TokenPayload | undefined> {
+  // Allow a static development token for local testing and unit tests.
+  if (idToken === 'dev-token') {
+    return {
+      sub: 'dev-user',
+      email: 'user@example.com',
+      name: 'Dev User',
+    } as TokenPayload;
+  }
+
   const ticket = await client.verifyIdToken({
     idToken,
     audience: process.env.GOOGLE_CLIENT_ID,

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,13 +1,10 @@
 import { Router, Request, Response } from 'express';
+import { authenticate } from '../middleware/auth';
 
 const router = Router();
 
-router.get('/profile', (req: Request, res: Response) => {
-  const authHeader = req.headers['authorization'];
-  if (authHeader !== 'Bearer dev-token') {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  res.json({ id: 'user1', email: 'user@example.com' });
+router.get('/profile', authenticate, (req: Request, res: Response) => {
+  res.json(req.user);
 });
 
 export default router;

--- a/backend/src/routes/content.ts
+++ b/backend/src/routes/content.ts
@@ -1,13 +1,10 @@
 import { Router, Request, Response } from 'express';
 import db from '../db/firestore';
+import { authenticate } from '../middleware/auth';
 
 const router = Router();
 
-router.get('/modules', async (req: Request, res: Response) => {
-  const authHeader = req.headers['authorization'];
-  if (authHeader !== 'Bearer dev-token') {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+router.get('/modules', authenticate, async (req: Request, res: Response) => {
   try {
     const snapshot = await db.collection('modules').get();
     const modules = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
+    "moduleResolution": "node",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
## Summary
- verify Google tokens and allow a dev token for tests
- secure content routes with auth middleware
- document setup and Cloud Run deployment

## Testing
- `npm test` *(fails: Cannot find module 'google-auth-library' or 'firebase-admin')*

------
https://chatgpt.com/codex/tasks/task_e_68b3f8e209e083309fac95932da73507