### PR TITLE
chore: migrate backend server tests to typescript

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test test/server.test.js",
+    "test": "npm run build && node --test -r ts-node/register test/server.test.ts",
     "seed:modules": "ts-node scripts/seedModules.ts"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- run server tests in TypeScript
- update npm test script for ts-node

## Testing
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd721f9083309e0b959a7fe2741b