### PR TITLE
feat: enforce auth with token verification

### DIFF
--- a/backend/test/server.test.ts
+++ b/backend/test/server.test.ts
@@ -69,6 +69,11 @@ test('requires auth', async () => {
   assert.strictEqual(res.status, 401);
 });
 
+test('rejects invalid token', async () => {
+  const res = await makeRequest('/content/modules', 'invalid-token');
+  assert.strictEqual(res.status, 401);
+});
+
 test('returns modules when authorized', async () => {
   const res = await makeRequest('/content/modules', 'valid-token');
   assert.strictEqual(res.status, 200);
@@ -82,6 +87,16 @@ test('returns user profile', async () => {
   assert.strictEqual(res.status, 200);
   const data = JSON.parse(res.body);
   assert.strictEqual(data.email, 'user@example.com');
+});
+
+test('requires auth for profile', async () => {
+  const res = await makeRequest('/auth/profile');
+  assert.strictEqual(res.status, 401);
+});
+
+test('rejects profile with invalid token', async () => {
+  const res = await makeRequest('/auth/profile', 'invalid-token');
+  assert.strictEqual(res.status, 401);
 });
 
 test('login returns url', async () => {


### PR DESCRIPTION
## Summary
- verify Google ID tokens and attach user info to requests
- secure profile and modules routes
- add tests covering authorized, missing token, and invalid token cases

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40311745c8330bc6a2fe10acee6c1