### PR TITLE
Add auth docs and configure modules page

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,16 @@ GOOGLE_CLIENT_SECRET=your-secret
 GOOGLE_REDIRECT_URI=http://localhost:3001/auth/callback
 ```
 
+## Authentication
+
+All protected routes expect an `Authorization` header with a Google ID token.
+For local development you can bypass the Google flow by sending the literal
+string `dev-token` as the bearer token:
+
+```
+Authorization: Bearer dev-token
+```
+
 ## Development
 
 Install dependencies and seed sample data:
@@ -30,6 +40,9 @@ npm install
 npm run seed:modules
 npm run start
 ```
+
+The `seed:modules` script inserts a few sample documents into the `modules`
+collection so the `/content/modules` endpoint returns data immediately.
 
 ## Testing
 

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,3 @@
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+NEXT_PUBLIC_DEV_TOKEN=dev-token

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,7 +13,9 @@ npm install
 2. Create a `.env.local` file in this directory:
 
 ```bash
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+NEXT_PUBLIC_DEV_TOKEN=dev-token # optional helper token for local development
 ```
 
 3. Run the development server:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,9 +7,12 @@ export interface Module {
 }
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
+const DEV_TOKEN = process.env.NEXT_PUBLIC_DEV_TOKEN
 
 export async function fetchModules(): Promise<Module[]> {
-  const res = await fetch(`${API_BASE_URL}/content/modules`)
+  const res = await fetch(`${API_BASE_URL}/content/modules`, {
+    headers: DEV_TOKEN ? { Authorization: `Bearer ${DEV_TOKEN}` } : {},
+  })
   if (!res.ok) {
     throw new Error('Failed to fetch modules')
   }


### PR DESCRIPTION
## Summary
- document backend environment variables, local auth token and sample data seeding
- configure frontend modules page API client and env variables
- provide example `.env.local` for development

## Testing
- `cd backend && npm test`
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b49b0a1b8c83309fd7a5130cae84b3