### PR TITLE
chore: add Cloud Build config and deployment docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,7 +4,7 @@ This project uses Google Cloud Build to build, test, and deploy the backend to C
 
 ## Environment Variables
 
-Add the following variables when configuring the Cloud Build trigger. They are passed to the Cloud Run service during deployment:
+When configuring the Cloud Build trigger, supply the following variables. They are injected into the Cloud Run service during deployment:
 
 - `PROJECT_ID`: Google Cloud project identifier where resources are deployed.
 - `_SERVICE_NAME`: Cloud Run service name. For this project the service name is `learning-hub`.
@@ -13,6 +13,14 @@ Add the following variables when configuring the Cloud Build trigger. They are p
 - `GOOGLE_CLIENT_SECRET`: Client secret paired with the OAuth client ID.
 - `GOOGLE_REDIRECT_URI`: Redirect URI configured for the OAuth client.
 - `FIREBASE_SERVICE_ACCOUNT`: JSON service account credentials for Firestore.
+
+## Rollout Process
+
+1. Push changes to the `main` branch.
+2. Cloud Build runs `npm ci`, executes tests, builds the Docker image, and deploys it to Cloud Run.
+3. The Cloud Run service `learning-hub` creates a new revision and directs all traffic to it.
+4. Verify the deployment in the Cloud Build logs and Cloud Run console.
+5. To roll back, redeploy a previous revision using `gcloud run deploy`.
 
 ## Manual Deployment
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,27 @@
-# Build stage
+# Build stage: install dependencies and compile TypeScript
 FROM node:18 AS build
 WORKDIR /app
-COPY package.json tsconfig.json ./
+
+# Install dependencies using npm ci for reproducible builds
+COPY package*.json tsconfig.json ./
+RUN npm ci
+
+# Copy source and build the application
 COPY src ./src
-RUN npm install
 RUN npm run build
 
-# Production stage
-FROM node:18-slim
+# Production stage: run the compiled application with production deps
+FROM node:18-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=8080
-COPY package.json .
-RUN npm install --omit=dev
+
+# Install only production dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy compiled output from the build stage
 COPY --from=build /app/dist ./dist
+
 EXPOSE 8080
 CMD ["node", "dist/index.js"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: gcr.io/cloud-builders/npm
     dir: backend
-    args: ['install']
+    args: ['ci']
   - name: gcr.io/cloud-builders/npm
     dir: backend
     args: ['test']
@@ -23,7 +23,11 @@ steps:
       - managed
       - --allow-unauthenticated
       - --set-env-vars
-      - GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI,FIREBASE_SERVICE_ACCOUNT=$FIREBASE_SERVICE_ACCOUNT
+      - >-
+        GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID,
+        GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET,
+        GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI,
+        FIREBASE_SERVICE_ACCOUNT=$FIREBASE_SERVICE_ACCOUNT
 images:
   - gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA
 substitutions:


### PR DESCRIPTION
## Summary
- add multi-stage backend Dockerfile
- add root cloudbuild.yaml to build, test, and deploy
- document env vars and rollout process in DEPLOYMENT.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a551becc8330ba9cb1a363a23a5a