### PR TITLE
Improve search resilience and suggestion UX

### DIFF
--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -9,15 +9,25 @@ indexModulesFromFirestore().catch(err => {
 });
 
 router.get('/', authenticate, async (req: Request, res: Response) => {
-  const q = (req.query.q as string) || '';
-  const results = await searchModules(q);
-  res.json(results);
+  try {
+    const q = ((req.query.q as string) || '').trim();
+    const results = await searchModules(q);
+    res.json(results);
+  } catch (err) {
+    console.error('Search failed', err);
+    res.status(500).json({ error: 'Search failed' });
+  }
 });
 
 router.get('/suggestions', authenticate, async (req: Request, res: Response) => {
-  const q = (req.query.q as string) || '';
-  const suggestions = await suggestModules(q);
-  res.json(suggestions);
+  try {
+    const q = ((req.query.q as string) || '').trim();
+    const suggestions = await suggestModules(q);
+    res.json(suggestions);
+  } catch (err) {
+    console.error('Suggestion lookup failed', err);
+    res.status(500).json({ error: 'Suggestion lookup failed' });
+  }
 });
 
 export default router;

--- a/backend/src/search/cloudSearch.ts
+++ b/backend/src/search/cloudSearch.ts
@@ -36,7 +36,8 @@ export async function searchModules(query: string): Promise<ModuleDoc[]> {
 export async function suggestModules(query: string): Promise<string[]> {
   await ensureIndex();
   const q = query.toLowerCase();
-  return index
+  const titles = index
     .filter(m => m.title.toLowerCase().startsWith(q))
     .map(m => m.title);
+  return Array.from(new Set(titles));
 }

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -41,7 +41,11 @@ export default function SearchPage() {
             <li
               key={s}
               className="p-2 cursor-pointer"
-              onClick={() => setQuery(s)}
+              onClick={async () => {
+                setQuery(s)
+                const data = await searchModules(s)
+                setResults(data)
+              }}
             >
               {s}
             </li>


### PR DESCRIPTION
## Summary
- handle errors in Cloud Search routes and trim queries
- de-duplicate module title suggestions on the backend
- trigger searches when a suggestion is selected in the UI

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4a6a384308330865c019c03eb7cde