### PR TITLE
feat: add Google auth middleware with tests

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { verifyIdToken } from '../auth/google';
+import { OAuth2Client } from 'google-auth-library';
 import { User } from '../types/user';
+
+const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 declare global {
   namespace Express {
@@ -19,7 +21,8 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
   const token = authHeader.substring('Bearer '.length);
 
   try {
-    const payload = await verifyIdToken(token);
+    const ticket = await client.verifyIdToken({ idToken: token, audience: process.env.GOOGLE_CLIENT_ID });
+    const payload = ticket.getPayload();
     if (!payload) {
       return res.status(401).json({ message: 'Invalid token' });
     }

--- a/backend/test/server.test.ts
+++ b/backend/test/server.test.ts
@@ -3,13 +3,24 @@ import assert from 'node:assert';
 import http from 'node:http';
 
 // Mock Google token verification
-import * as googleAuth from '../src/auth/google';
-(googleAuth as any).verifyIdToken = async (token: string) => {
-  if (token === 'valid-token') {
-    return { sub: 'user1', email: 'user@example.com', name: 'Test User' } as any;
+import { OAuth2Client } from 'google-auth-library';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(OAuth2Client.prototype as any).verifyIdToken = async ({ idToken }: { idToken: string }) => {
+  if (idToken === 'valid-token') {
+    return {
+      getPayload: () => ({ sub: 'user1', email: 'user@example.com', name: 'Test User' }),
+    } as any;
   }
-  if (token === 'admin-token') {
-    return { sub: 'admin1', email: 'admin@example.com', name: 'Admin User', role: 'admin' } as any;
+  if (idToken === 'admin-token') {
+    return {
+      getPayload: () => ({
+        sub: 'admin1',
+        email: 'admin@example.com',
+        name: 'Admin User',
+        role: 'admin',
+      }),
+    } as any;
   }
   throw new Error('Invalid token');
 };


### PR DESCRIPTION
## Summary
- validate Google ID tokens via OAuth2Client middleware
- mock OAuth2Client in tests to check authorized and unauthorized access

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5143ae62483309613de8cb7588ce1