### PR TITLE
feat: use Firestore for modules

### DIFF
--- a/backend/scripts/seedModules.ts
+++ b/backend/scripts/seedModules.ts
@@ -1,6 +1,11 @@
 import db from '../src/db/firestore';
 
-const modules = [
+interface Module {
+  title: string;
+  description: string;
+}
+
+const modules: Module[] = [
   { title: 'Intro to GBS', description: 'Welcome module' },
   { title: 'Advanced Processes', description: 'Deep dive' },
 ];
@@ -15,7 +20,9 @@ async function seed() {
   console.log('Seeded modules');
 }
 
-seed().then(() => process.exit(0)).catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+seed()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/backend/src/db/firestore.ts
+++ b/backend/src/db/firestore.ts
@@ -1,23 +1,17 @@
-import admin, { ServiceAccount } from 'firebase-admin';
+import { initializeApp, cert, ServiceAccount } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
 
 let db: FirebaseFirestore.Firestore;
 
 try {
-  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT
-    ? (JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT) as ServiceAccount)
-    : undefined;
-
-  if (!admin.apps.length) {
-    if (serviceAccount) {
-      admin.initializeApp({
-        credential: admin.credential.cert(serviceAccount),
-      });
-    } else {
-      admin.initializeApp();
-    }
+  const credentials = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (!credentials) {
+    throw new Error('FIREBASE_SERVICE_ACCOUNT is not defined');
   }
 
-  db = admin.firestore();
+  const serviceAccount = JSON.parse(credentials) as ServiceAccount;
+  const app = initializeApp({ credential: cert(serviceAccount) });
+  db = getFirestore(app);
 } catch {
   // Allow tests to mock Firestore when credentials aren't provided
   db = {} as any;

--- a/backend/src/routes/content.ts
+++ b/backend/src/routes/content.ts
@@ -4,12 +4,18 @@ import { authenticate } from '../middleware/auth';
 
 const router = Router();
 
-router.get('/modules', authenticate, async (req: Request, res: Response) => {
+interface Module {
+  id: string;
+  title: string;
+  description: string;
+}
+
+router.get('/modules', authenticate, async (_req: Request, res: Response) => {
   try {
     const snapshot = await db.collection('modules').get();
-    const modules = snapshot.docs.map((doc: any) => ({ id: doc.id, ...doc.data() }));
+    const modules: Module[] = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<Module, 'id'>) }));
     res.json(modules);
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Failed to fetch modules' });
   }
 });


### PR DESCRIPTION
## Summary
- initialize Firestore with service-account credentials
- load modules from Firestore instead of hardcoded array
- add seed script for module collection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b514f559b08330a295c9a0ff37f365