### PR TITLE
feat: add analytics and progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Useful endpoints:
 
 For testing, the backend accepts a fake token `valid-token` that resolves to a mock user.
 
+### Analytics & Progress Tracking
+
+The backend exposes endpoints for recording user progress and arbitrary analytics events.
+
+- `POST /progress/complete` – store a completed module in Firestore.
+- `GET /progress/user/:userId` – retrieve a user's completed modules.
+- `POST /analytics/events` – emit interaction events which are streamed into BigQuery.
+- `GET /analytics/dashboard` – returns aggregated event counts from BigQuery for reporting.
+
+Firestore is used to persist per-user progress while analytics events are inserted into the
+BigQuery dataset `analytics.events`.
+
 ## Frontend
 
 The Next.js app lives in `frontend/` and uses React Query to call the backend.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ app.use(express.json());
 
 app.use('/auth', authRouter);
 app.use('/content', contentRouter);
-app.use('/analytics', analyticsRouter);
+app.use(analyticsRouter);
 app.use('/search', searchRouter);
 app.use('/notifications', notificationsRouter);
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -43,3 +43,35 @@ export async function fetchSuggestions(query: string): Promise<string[]> {
   }
   return res.json()
 }
+
+export async function trackEvent(
+  eventType: string,
+  moduleId?: string,
+  metadata?: Record<string, unknown>
+) {
+  const res = await fetch(`${API_BASE_URL}/analytics/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(DEV_TOKEN ? { Authorization: `Bearer ${DEV_TOKEN}` } : {}),
+    },
+    body: JSON.stringify({ eventType, moduleId, metadata }),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to track event')
+  }
+}
+
+export async function completeModule(moduleId: string) {
+  const res = await fetch(`${API_BASE_URL}/progress/complete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(DEV_TOKEN ? { Authorization: `Bearer ${DEV_TOKEN}` } : {}),
+    },
+    body: JSON.stringify({ moduleId }),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to complete module')
+  }
+}

--- a/frontend/src/pages/modules.tsx
+++ b/frontend/src/pages/modules.tsx
@@ -1,4 +1,4 @@
-import { useModules } from '../api/client'
+import { useModules, trackEvent, completeModule } from '../api/client'
 
 export default function ModulesPage() {
   const { data, isLoading, error } = useModules()
@@ -11,9 +11,23 @@ export default function ModulesPage() {
       <h1 className="text-2xl font-bold mb-4">Modules</h1>
       <ul className="space-y-4">
         {data?.map((m) => (
-          <li key={m.id} className="border p-4 rounded">
+          <li
+            key={m.id}
+            className="border p-4 rounded cursor-pointer"
+            onClick={() => trackEvent('module start', m.id)}
+          >
             <h2 className="text-xl font-semibold">{m.title}</h2>
             <p className="text-gray-600">{m.description}</p>
+            <button
+              className="mt-2 text-sm text-blue-600 underline"
+              onClick={(e) => {
+                e.stopPropagation()
+                completeModule(m.id)
+                trackEvent('module complete', m.id)
+              }}
+            >
+              Mark Complete
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- track module completions in Firestore via new `/progress` endpoints
- ingest analytics events into BigQuery and expose dashboard summary
- add frontend hooks to emit events and mark modules complete

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(prompts for ESLint config and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68b5174c2bd88330958888d99624de1b