### PR TITLE
feat: add Cloud Build config and multi-stage Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,27 +1,27 @@
-# Multi-stage Dockerfile for building and running the backend on Cloud Run
+# Multi-stage Dockerfile for building and running the backend
 # Build stage: install dependencies and compile TypeScript
 FROM node:18 AS build
 WORKDIR /app
 
-# Install dependencies using npm ci for reproducible builds
+# Install dependencies with npm ci for reproducible builds
 COPY package*.json tsconfig.json ./
 RUN npm ci
 
-# Copy source and build the application
+# Copy source and build the app
 COPY src ./src
 RUN npm run build
 
-# Production stage: run the compiled application with production deps
+# Remove dev dependencies to prepare prod node_modules
+RUN npm prune --production
+
+# Runtime stage
 FROM node:18-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=8080
 
-# Install only production dependencies
-COPY package*.json ./
-RUN npm ci --omit=dev
-
-# Copy compiled output from the build stage
+# Copy production node_modules and compiled output from build stage
+COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
 EXPOSE 8080

--- a/cloudbuild-trigger.yaml
+++ b/cloudbuild-trigger.yaml
@@ -1,0 +1,14 @@
+# Cloud Build trigger configuration for main branch
+apiVersion: cloudbuild.googleapis.com/v1
+kind: BuildTrigger
+metadata:
+  name: learning-hub-main
+spec:
+  description: Build and deploy backend when commits are pushed to main
+  triggerTemplate:
+    branchName: main
+    repoName: gbsenterprise-sora
+  filename: cloudbuild.yaml
+  substitutions:
+    _SERVICE_NAME: learning-hub
+    _REGION: us-central1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,17 +11,19 @@ steps:
     dir: backend
     args: ['test', '--', '--runInBand']
 
-  # Build and push the production container image
+  # Build the multi-stage container image
   - id: build-image
     name: gcr.io/cloud-builders/docker
-    args: ['build','-t','gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA','backend']
+    args: ['build','-f','backend/Dockerfile','-t','gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA','backend']
+
+  # Push the image to Container Registry
   - id: push-image
     name: gcr.io/cloud-builders/docker
     args: ['push','gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA']
 
   # Deploy the image to Cloud Run
   - id: deploy
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     entrypoint: gcloud
     args:
       - run


### PR DESCRIPTION
## Summary
- build Node backend with multi-stage Dockerfile and prune dev dependencies
- run Cloud Build pipeline to test, build and deploy backend image
- configure Cloud Build trigger for main branch deployments

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bdd11b5483308eba824c95cb90f0