### PR TITLE
feat: add analytics routes and tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,6 +11,7 @@ Set these variables in your environment or a `.env` file:
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` – Google OAuth credentials.
 - `JWT_SECRET` – secret used to sign JWT access and refresh tokens.
 - `FIRESTORE_EMULATOR_HOST` – optional host for the Firestore emulator.
+- BigQuery uses application default credentials. Set `GOOGLE_APPLICATION_CREDENTIALS` to a service account JSON key if needed.
 
 Example:
 
@@ -62,3 +63,22 @@ npm test
 ```
 
 Tests mock Firestore so no external services are needed.
+
+## Analytics
+
+Training progress is persisted to Firestore and richer analytics events are
+streamed to BigQuery.
+
+Routes:
+
+- `POST /progress/complete` – mark a module completed for the authenticated user.
+- `GET /progress/user/:userId` – return progress for a given user.
+- `POST /analytics/events` – ingest a custom event which is inserted into the
+  BigQuery dataset `analytics` table `events`.
+- `GET /analytics/dashboard` – aggregate events by type and module from
+  BigQuery.
+
+Create the dataset and table in BigQuery ahead of time with a schema matching
+the fields above. For local development provide credentials via the
+`GOOGLE_APPLICATION_CREDENTIALS` environment variable or another method supported
+by the Google Cloud SDK.

--- a/backend/test/analytics.test.ts
+++ b/backend/test/analytics.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import app from '../src/index';
+
+const insertMock = jest.fn().mockResolvedValue(undefined);
+const queryMock = jest.fn();
+
+jest.mock('../src/db/bigquery', () => ({
+  dataset: () => ({ table: () => ({ insert: insertMock }) }),
+  query: queryMock,
+}));
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user1' };
+    next();
+  },
+}));
+
+describe('Analytics events', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  beforeEach(() => {
+    insertMock.mockClear();
+    queryMock.mockClear();
+  });
+
+  it('streams events to BigQuery', async () => {
+    const res = await request(app)
+      .post('/analytics/events')
+      .send({ eventType: 'view', moduleId: 'm1', metadata: { foo: 'bar' } });
+    expect(res.status).toBe(201);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    const rows = insertMock.mock.calls[0][0];
+    expect(rows[0]).toMatchObject({
+      userId: 'user1',
+      eventType: 'view',
+      moduleId: 'm1',
+    });
+  });
+
+  it('requires eventType', async () => {
+    const res = await request(app).post('/analytics/events').send({});
+    expect(res.status).toBe(400);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('returns dashboard summary', async () => {
+    queryMock.mockResolvedValue([[{ eventType: 'view', moduleId: 'm1', total: '1' }]]);
+    const res = await request(app).get('/analytics/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ eventType: 'view', moduleId: 'm1', total: '1' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add analytics routes for progress tracking and BigQuery ingestion
- document BigQuery setup and analytics endpoints
- add unit tests for event ingestion and dashboard summary

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b5bee0ebf08330abca6a1a53fc5e9b