### PR TITLE
Add Cloud Search routes and debounced frontend search

### DIFF
--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -11,6 +11,9 @@ indexModulesFromFirestore().catch(err => {
 router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
     const q = ((req.query.q as string) || '').trim();
+    if (!q) {
+      return res.json([]);
+    }
     const results = await searchModules(q);
     res.json(results);
   } catch (err) {
@@ -22,6 +25,9 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
 router.get('/suggestions', authenticate, async (req: Request, res: Response) => {
   try {
     const q = ((req.query.q as string) || '').trim();
+    if (!q) {
+      return res.json([]);
+    }
     const suggestions = await suggestModules(q);
     res.json(suggestions);
   } catch (err) {

--- a/backend/src/search/cloudSearch.ts
+++ b/backend/src/search/cloudSearch.ts
@@ -10,7 +10,13 @@ let index: ModuleDoc[] = [];
 let indexed = false;
 
 async function loadIndex() {
-  const snapshot = await db.collection('modules').get();
+  if (typeof (db as any).collection !== 'function') {
+    index = [];
+    indexed = true;
+    return;
+  }
+
+  const snapshot = await (db as any).collection('modules').get();
   index = snapshot.docs.map((doc: any) => ({ id: doc.id, ...doc.data() }));
   indexed = true;
 }
@@ -28,14 +34,22 @@ async function ensureIndex(): Promise<void> {
 export async function searchModules(query: string): Promise<ModuleDoc[]> {
   await ensureIndex();
   const q = query.toLowerCase();
-  return index.filter(m =>
-    m.title.toLowerCase().includes(q) || m.description.toLowerCase().includes(q)
+  if (!q) {
+    return [];
+  }
+  return index.filter(
+    m =>
+      m.title.toLowerCase().includes(q) ||
+      m.description.toLowerCase().includes(q)
   );
 }
 
 export async function suggestModules(query: string): Promise<string[]> {
   await ensureIndex();
   const q = query.toLowerCase();
+  if (!q) {
+    return [];
+  }
   const titles = index
     .filter(m => m.title.toLowerCase().startsWith(q))
     .map(m => m.title);

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -9,20 +9,22 @@ export default function SearchPage() {
   useEffect(() => {
     if (!query) {
       setSuggestions([])
+      setResults([])
       return
     }
     const id = setTimeout(() => {
       fetchSuggestions(query)
         .then(setSuggestions)
         .catch(() => setSuggestions([]))
+      searchModules(query)
+        .then(setResults)
+        .catch(() => setResults([]))
     }, 300)
     return () => clearTimeout(id)
   }, [query])
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const onSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const data = await searchModules(query)
-    setResults(data)
   }
 
   return (
@@ -41,10 +43,9 @@ export default function SearchPage() {
             <li
               key={s}
               className="p-2 cursor-pointer"
-              onClick={async () => {
+              onClick={() => {
                 setQuery(s)
-                const data = await searchModules(s)
-                setResults(data)
+                setSuggestions([])
               }}
             >
               {s}


### PR DESCRIPTION
## Summary
- ensure Cloud Search index initializes safely and skip empty queries
- expose `/search` and `/search/suggestions` API routes
- add debounced search UI querying suggestions and results

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5c03cb0e48330a1bc3409709d2a0a